### PR TITLE
Reorganize docs to remove Phase 1/2 distinction and update README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
    - Ensure changes don't break documented behavior
 
 3. **docs/IMPLEMENTATION_SUMMARY.md** - Technical implementation details
-   - Phase 1 and Phase 2 implementation status
+   - Current implementation status
    - Architecture flow and component interactions
    - Test coverage and success criteria
 
@@ -44,7 +44,7 @@ This controller is designed to intercept the Kubernetes pod readiness process us
 
 Application owners control warmup behavior through **pod annotations**. This provides a simple, declarative way to enable/disable warmup without requiring additional resources.
 
-#### Phase 1 & 2: Annotation-Based Configuration (Implemented)
+#### Annotation-Based Configuration
 
 **Enable warmup with annotations:**
 ```yaml

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -664,9 +664,9 @@ kubectl cluster-info --context kind-kube-booster-dev
 - [Kubernetes readiness gates](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-readiness-gate)
 - [Kubebuilder book](https://book.kubebuilder.io/)
 
-## Future Development (Phase 3+)
+## Future Development
 
-Phase 2 HTTP warmup execution is complete. See [CLAUDE.md](../CLAUDE.md) for the complete roadmap. Future areas:
+HTTP warmup execution is complete. See [CLAUDE.md](../CLAUDE.md) for the complete roadmap. Future areas:
 
 1. **gRPC Support**
    - Add gRPC warmup capability

--- a/docs/IMPLEMENTATION_SUMMARY.md
+++ b/docs/IMPLEMENTATION_SUMMARY.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-Successfully implemented Phase 1 and Phase 2 of kube-booster: a Kubernetes mutating webhook and controller that manages pod readiness gates and executes HTTP warmup requests before pods become ready.
+Successfully implemented kube-booster: a Kubernetes mutating webhook and controller that manages pod readiness gates and executes HTTP warmup requests before pods become ready.
 
 ## What Was Implemented
 
-### Phase 1: Core Infrastructure
+### Core Infrastructure
 
 ### Core Components
 
@@ -124,7 +124,7 @@ Testing:
 sigs.k8s.io/controller-runtime/pkg/client/fake
 ```
 
-### Phase 2: HTTP Warmup Execution
+### HTTP Warmup Execution
 
 #### Warmup Package (`pkg/warmup/`)
 
@@ -241,7 +241,7 @@ Implemented for controller-runtime v0.23.0 with latest APIs:
 - `metricsserver.Options` for metrics configuration
 - `webhook.NewServer()` for webhook server setup
 
-## Success Criteria (Phase 1)
+## Success Criteria - Core Infrastructure
 
 ✅ Webhook successfully injects readiness gates for annotated pods
 ✅ Controller successfully updates conditions for pods with readiness gates
@@ -250,7 +250,7 @@ Implemented for controller-runtime v0.23.0 with latest APIs:
 ✅ Code builds successfully
 ✅ Webhook fails open (pods created even if webhook down)
 
-## Success Criteria (Phase 2)
+## Success Criteria - HTTP Warmup
 
 ✅ Controller parses warmup configuration from annotations
 ✅ HTTP warmup requests sent using Vegeta load testing library
@@ -292,7 +292,7 @@ Implemented for controller-runtime v0.23.0 with latest APIs:
 
 ## Next Steps
 
-Future enhancements (Phase 3+):
+Future enhancements:
 1. **gRPC Support**: Add gRPC warmup request capability
 2. **Prometheus Metrics**: Export warmup metrics for monitoring dashboards
 3. **Kubernetes Events**: Record warmup results as pod events
@@ -336,7 +336,7 @@ Future enhancements (Phase 3+):
 
 ## Conclusion
 
-Phase 1 and Phase 2 implementation is complete and ready for testing. The system provides:
+The implementation is complete and ready for testing. The system provides:
 
 ✓ End-to-end warmup functionality via annotations
 ✓ HTTP warmup requests using Vegeta load testing library

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -6,9 +6,9 @@ This guide shows you how to deploy and use kube-booster in your Kubernetes clust
 
 kube-booster is a Kubernetes controller that ensures smooth application launches by managing warmup readiness gates. It prevents pods from receiving traffic until they are fully warmed up.
 
-**Current Status**: Phase 1 and Phase 2 are implemented:
-- **Phase 1**: Mutating webhook injects readiness gates for annotated pods
-- **Phase 2**: Controller sends HTTP warmup requests using Vegeta before marking pods ready
+**Current Features**:
+- Mutating webhook injects readiness gates for annotated pods
+- Controller sends HTTP warmup requests using Vegeta before marking pods ready
 - Fail-open behavior ensures pods become ready even if warmup fails
 
 ## Prerequisites
@@ -94,13 +94,13 @@ spec:
 
 ### Configuration Annotations
 
-| Annotation | Description | Default | Status |
-|------------|-------------|---------|--------|
-| `kube-booster.io/warmup` | Enable/disable warmup (`enabled`/`disabled`) | `disabled` | ✅ Phase 1 |
-| `kube-booster.io/warmup-endpoint` | HTTP endpoint path for warmup requests | `/` | ✅ Phase 2 |
-| `kube-booster.io/warmup-requests` | Number of warmup requests to send | `3` | ✅ Phase 2 |
-| `kube-booster.io/warmup-duration` | Total duration for warmup (e.g., `30s`, `1m`) | `30s` | ✅ Phase 2 |
-| `kube-booster.io/warmup-port` | Container port for warmup requests | Auto-detected | ✅ Phase 2 |
+| Annotation | Description | Default |
+|------------|-------------|---------|
+| `kube-booster.io/warmup` | Enable/disable warmup (`enabled`/`disabled`) | `disabled` |
+| `kube-booster.io/warmup-endpoint` | HTTP endpoint path for warmup requests | `/` |
+| `kube-booster.io/warmup-requests` | Number of warmup requests to send | `3` |
+| `kube-booster.io/warmup-duration` | Total duration for warmup (e.g., `30s`, `1m`) | `30s` |
+| `kube-booster.io/warmup-port` | Container port for warmup requests | Auto-detected |
 
 ### Example: Complete Application
 
@@ -449,7 +449,7 @@ After warmup completes, the controller logs:
 
 - Review [DEVELOPMENT.md](DEVELOPMENT.md) for building from source and contributing
 - Check [IMPLEMENTATION_SUMMARY.md](IMPLEMENTATION_SUMMARY.md) for technical details
-- See Phase 2 roadmap in [CLAUDE.md](../CLAUDE.md) for upcoming features
+- See [CLAUDE.md](../CLAUDE.md) for architecture and future roadmap
 
 ## Support
 

--- a/hack/quick_test.sh
+++ b/hack/quick_test.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Quick test script for kube-booster Phase 1 & 2
+# Quick test script for kube-booster
 # This script performs basic smoke tests to verify the implementation
 
 set -e
@@ -10,7 +10,7 @@ TEST_POD="test-warmup-pod"
 CONTROLLER_NAMESPACE="kube-system"
 
 echo "=========================================="
-echo "kube-booster Phase 1 & 2 Quick Test"
+echo "kube-booster Quick Test"
 echo "=========================================="
 echo ""
 
@@ -149,7 +149,7 @@ echo "=========================================="
 echo "✓ All tests passed!"
 echo "=========================================="
 echo ""
-echo "Phase 1 & 2 implementation is working correctly."
+echo "kube-booster implementation is working correctly."
 echo ""
 echo "Warmup features verified:"
 echo "  - Readiness gate injection via mutating webhook"


### PR DESCRIPTION
## Summary

- Remove Phase 1/Phase 2 terminology from all documentation, presenting features as unified "current implementation"
- Update README.md with new title "Kube Booster", emoji headers, and actual usage instructions replacing placeholders
- Simplify feature descriptions and tables across all documentation files

## Test plan

- [x] Verify no remaining "Phase 1" or "Phase 2" references in documentation
- [x] Run `make test` to ensure no regressions
- [x] Review updated README for accuracy and completeness
- [x] Review documentation flow for coherent narrative

🤖 Generated with [Claude Code](https://claude.com/claude-code)