### PR TITLE
Fix plugin install SSH error in Claude GitHub Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Configure git to use HTTPS for GitHub
+        run: git config --global url."https://github.com/".insteadOf "git@github.com:"
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1


### PR DESCRIPTION
## Summary
- Add git config step to rewrite SSH URLs (`git@github.com:`) to HTTPS (`https://github.com/`) before the Claude Code action runs
- Fixes `Permission denied (publickey)` error when installing `gh-devflow-plugins` marketplace plugin, since the GitHub Actions runner has no SSH keys configured

## Test plan
- [ ] Trigger the Claude GitHub Action by mentioning `@claude` on an issue or PR and verify the plugin installs successfully