### PR TITLE
feat: add Prometheus and Grafana monitoring sample manifests

### DIFF
--- a/config/samples/monitoring.yaml
+++ b/config/samples/monitoring.yaml
@@ -68,6 +68,17 @@ data:
 
   rules.yaml: |
     groups:
+      - name: kube-booster-recording
+        interval: 15s
+        rules:
+          - record: kube_booster_warmup_total:rate5m
+            expr: sum(rate(kube_booster_warmup_total[5m])) by (namespace, result)
+          - record: kube_booster_warmup_duration_seconds_bucket:rate5m
+            expr: sum(rate(kube_booster_warmup_duration_seconds_bucket[5m])) by (le, namespace)
+          - record: kube_booster_warmup_queue_wait_seconds_bucket:rate5m
+            expr: sum(rate(kube_booster_warmup_queue_wait_seconds_bucket[5m])) by (le, namespace)
+          - record: kube_booster_warmup_requests_total:rate5m
+            expr: sum(rate(kube_booster_warmup_requests_total[5m])) by (namespace)
       - name: kube-booster
         rules:
           - alert: KubeBoosterHighWarmupFailureRate
@@ -322,7 +333,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(rate(kube_booster_warmup_total{result=\"success\", namespace=~\"$namespace\"}[5m])) / sum(rate(kube_booster_warmup_total{namespace=~\"$namespace\"}[5m]))",
+              "expr": "sum(kube_booster_warmup_total:rate5m{result=\"success\", namespace=~\"$namespace\"}) / sum(kube_booster_warmup_total:rate5m{namespace=~\"$namespace\"})",
               "legendFormat": "Success Rate",
               "refId": "A"
             }
@@ -442,7 +453,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(rate(kube_booster_warmup_total{namespace=~\"$namespace\"}[5m])) by (result) * 60",
+              "expr": "sum(kube_booster_warmup_total:rate5m{namespace=~\"$namespace\"}) by (result) * 60",
               "legendFormat": "{{result}}",
               "refId": "A"
             }
@@ -532,7 +543,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "histogram_quantile(0.50, sum(rate(kube_booster_warmup_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.50, sum(kube_booster_warmup_duration_seconds_bucket:rate5m{namespace=~\"$namespace\"}) by (le))",
               "legendFormat": "P50",
               "refId": "A"
             },
@@ -541,7 +552,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "histogram_quantile(0.95, sum(rate(kube_booster_warmup_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(kube_booster_warmup_duration_seconds_bucket:rate5m{namespace=~\"$namespace\"}) by (le))",
               "legendFormat": "P95",
               "refId": "B"
             },
@@ -550,7 +561,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "histogram_quantile(0.99, sum(rate(kube_booster_warmup_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(kube_booster_warmup_duration_seconds_bucket:rate5m{namespace=~\"$namespace\"}) by (le))",
               "legendFormat": "P99",
               "refId": "C"
             }
@@ -648,7 +659,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "histogram_quantile(0.50, sum(rate(kube_booster_warmup_queue_wait_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.50, sum(kube_booster_warmup_queue_wait_seconds_bucket:rate5m{namespace=~\"$namespace\"}) by (le))",
               "legendFormat": "P50",
               "refId": "A"
             },
@@ -657,7 +668,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "histogram_quantile(0.95, sum(rate(kube_booster_warmup_queue_wait_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(kube_booster_warmup_queue_wait_seconds_bucket:rate5m{namespace=~\"$namespace\"}) by (le))",
               "legendFormat": "P95",
               "refId": "B"
             },
@@ -666,7 +677,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "histogram_quantile(0.99, sum(rate(kube_booster_warmup_queue_wait_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(kube_booster_warmup_queue_wait_seconds_bucket:rate5m{namespace=~\"$namespace\"}) by (le))",
               "legendFormat": "P99",
               "refId": "C"
             }
@@ -911,7 +922,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(rate(kube_booster_warmup_requests_total{namespace=~\"$namespace\"}[5m]))",
+              "expr": "sum(kube_booster_warmup_requests_total:rate5m{namespace=~\"$namespace\"})",
               "legendFormat": "Request Rate",
               "refId": "A"
             }
@@ -1000,7 +1011,7 @@ data:
                 "type": "prometheus",
                 "uid": "${datasource}"
               },
-              "expr": "sum(rate(kube_booster_warmup_total{namespace=~\"$namespace\"}[5m])) by (namespace, result) * 60",
+              "expr": "sum(kube_booster_warmup_total:rate5m{namespace=~\"$namespace\"}) by (namespace, result) * 60",
               "legendFormat": "{{namespace}} - {{result}}",
               "refId": "A"
             }

--- a/config/samples/monitoring.yaml
+++ b/config/samples/monitoring.yaml
@@ -161,6 +161,12 @@ spec:
           limits:
             cpu: 500m
             memory: 512Mi
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 65534
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
       volumes:
       - name: config
         configMap:
@@ -1110,6 +1116,12 @@ spec:
           limits:
             cpu: 200m
             memory: 256Mi
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 472
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
       volumes:
       - name: datasources
         configMap:

--- a/config/samples/monitoring.yaml
+++ b/config/samples/monitoring.yaml
@@ -7,32 +7,29 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: prometheus
+  name: kube-booster-prometheus
   namespace: monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: prometheus
+  name: kube-booster-prometheus
 rules:
 - apiGroups: [""]
   resources: ["pods", "nodes", "endpoints", "services"]
   verbs: ["get", "list", "watch"]
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: prometheus
+  name: kube-booster-prometheus
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: prometheus
+  name: kube-booster-prometheus
 subjects:
 - kind: ServiceAccount
-  name: prometheus
+  name: kube-booster-prometheus
   namespace: monitoring
 ---
 apiVersion: v1
@@ -133,7 +130,7 @@ spec:
       labels:
         app: prometheus
     spec:
-      serviceAccountName: prometheus
+      serviceAccountName: kube-booster-prometheus
       containers:
       - name: prometheus
         image: prom/prometheus:v3.4.1

--- a/config/samples/monitoring.yaml
+++ b/config/samples/monitoring.yaml
@@ -80,6 +80,7 @@ data:
                 /
                 sum(rate(kube_booster_warmup_total[5m]))
               ) > 0.1
+              and sum(rate(kube_booster_warmup_total[5m])) > 0
             for: 5m
             labels:
               severity: warning

--- a/config/samples/monitoring.yaml
+++ b/config/samples/monitoring.yaml
@@ -40,7 +40,7 @@ metadata:
 data:
   prometheus.yml: |
     global:
-      scrape_interval: 15s
+      scrape_interval: 15s      # increase to 30s or 60s for large clusters
       evaluation_interval: 15s
 
     rule_files:
@@ -180,7 +180,8 @@ spec:
         configMap:
           name: prometheus-config
       - name: storage
-        emptyDir: {}
+        emptyDir: {}  # ephemeral — for production use a PersistentVolumeClaim
+                      # and pass --storage.tsdb.retention.size to Prometheus
 ---
 apiVersion: v1
 kind: Service
@@ -224,7 +225,7 @@ data:
       - name: kube-booster
         type: file
         options:
-          path: /var/lib/grafana/dashboards
+          path: /var/lib/grafana/dashboards  # must match mountPath for grafana-dashboard-kube-booster in the Grafana Deployment
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -1106,6 +1107,8 @@ spec:
         - containerPort: 3000
           name: web
         env:
+        # For development/demo only — disable anonymous access and configure
+        # proper authentication before deploying to shared or production clusters.
         - name: GF_AUTH_ANONYMOUS_ENABLED
           value: "true"
         - name: GF_AUTH_ANONYMOUS_ORG_ROLE

--- a/config/samples/monitoring.yaml
+++ b/config/samples/monitoring.yaml
@@ -1,0 +1,1135 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+# Prometheus – ServiceAccount, RBAC, config, and deployment
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+  namespace: monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups: [""]
+  resources: ["pods", "nodes", "endpoints", "services"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: monitoring
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+      evaluation_interval: 15s
+
+    rule_files:
+      - /etc/prometheus/rules/rules.yaml
+
+    scrape_configs:
+      - job_name: 'kube-booster'
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          # Keep only kube-booster pods
+          - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+            regex: kube-booster
+            action: keep
+          # Keep only the metrics port (8080)
+          - source_labels: [__meta_kubernetes_pod_container_port_number]
+            regex: "8080"
+            action: keep
+          # Use pod name as instance label
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: instance
+          # Preserve namespace label
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: kubernetes_namespace
+
+  rules.yaml: |
+    groups:
+      - name: kube-booster
+        rules:
+          - alert: KubeBoosterHighWarmupFailureRate
+            expr: |
+              (
+                sum(rate(kube_booster_warmup_total{result="failure"}[5m]))
+                /
+                sum(rate(kube_booster_warmup_total[5m]))
+              ) > 0.1
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "High warmup failure rate"
+              description: "More than 10% of warmups are failing in the last 5 minutes"
+          - alert: KubeBoosterSlowWarmup
+            expr: |
+              histogram_quantile(0.95, sum(rate(kube_booster_warmup_duration_seconds_bucket[5m])) by (le))
+              > 60
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Slow warmup executions"
+              description: "P95 warmup duration is over 60 seconds"
+          - alert: KubeBoosterWarmupBacklog
+            expr: sum(kube_booster_warmup_active_pods) > 10
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "Warmup backlog building up"
+              description: "More than 10 pods are actively executing warmup"
+          - alert: KubeBoosterHighSemaphoreWaitTime
+            expr: |
+              histogram_quantile(0.95, sum(rate(kube_booster_warmup_queue_wait_seconds_bucket[5m])) by (le))
+              > 10
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              summary: "High warmup semaphore wait time"
+              description: "P95 wait time for the warmup semaphore exceeds 10 seconds — consider increasing --max-concurrent-warmups"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: monitoring
+  labels:
+    app: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      serviceAccountName: prometheus
+      containers:
+      - name: prometheus
+        image: prom/prometheus:v3.4.1
+        args:
+        - --config.file=/etc/prometheus/prometheus.yml
+        - --storage.tsdb.path=/prometheus
+        - --web.console.libraries=/usr/share/prometheus/console_libraries
+        - --web.console.templates=/usr/share/prometheus/consoles
+        ports:
+        - containerPort: 9090
+          name: web
+        volumeMounts:
+        - name: config
+          mountPath: /etc/prometheus/prometheus.yml
+          subPath: prometheus.yml
+        - name: config
+          mountPath: /etc/prometheus/rules/rules.yaml
+          subPath: rules.yaml
+        - name: storage
+          mountPath: /prometheus
+        resources:
+          requests:
+            cpu: 200m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+      volumes:
+      - name: config
+        configMap:
+          name: prometheus-config
+      - name: storage
+        emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: monitoring
+spec:
+  selector:
+    app: prometheus
+  ports:
+  - name: web
+    port: 9090
+    targetPort: 9090
+  type: ClusterIP
+---
+# Grafana – datasource provisioning, dashboard provisioning, and deployment
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  namespace: monitoring
+data:
+  prometheus.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        url: http://prometheus:9090
+        isDefault: true
+        access: proxy
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards-provider
+  namespace: monitoring
+data:
+  dashboards.yaml: |
+    apiVersion: 1
+    providers:
+      - name: kube-booster
+        type: file
+        options:
+          path: /var/lib/grafana/dashboards
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-kube-booster
+  namespace: monitoring
+data:
+  kube-booster.json: |
+    {
+      "annotations": {
+        "list": []
+      },
+      "description": "Prometheus metrics dashboard for kube-booster warmup observability",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.9
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(rate(kube_booster_warmup_total{result=\"success\", namespace=~\"$namespace\"}[5m])) / sum(rate(kube_booster_warmup_total{namespace=~\"$namespace\"}[5m]))",
+              "legendFormat": "Success Rate",
+              "refId": "A"
+            }
+          ],
+          "title": "Warmup Success Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "failure"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "success"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [
+                "sum"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(rate(kube_booster_warmup_total{namespace=~\"$namespace\"}[5m])) by (result) * 60",
+              "legendFormat": "{{result}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Warmup Rate (per minute)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.50, sum(rate(kube_booster_warmup_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le))",
+              "legendFormat": "P50",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.95, sum(rate(kube_booster_warmup_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le))",
+              "legendFormat": "P95",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum(rate(kube_booster_warmup_duration_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le))",
+              "legendFormat": "P99",
+              "refId": "C"
+            }
+          ],
+          "title": "Warmup Duration",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 30
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "id": 9,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.50, sum(rate(kube_booster_warmup_queue_wait_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le))",
+              "legendFormat": "P50",
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.95, sum(rate(kube_booster_warmup_queue_wait_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le))",
+              "legendFormat": "P95",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "histogram_quantile(0.99, sum(rate(kube_booster_warmup_queue_wait_seconds_bucket{namespace=~\"$namespace\"}[5m])) by (le))",
+              "legendFormat": "P99",
+              "refId": "C"
+            }
+          ],
+          "description": "Time pods spend waiting to acquire the warmup semaphore. High values indicate --max-concurrent-warmups is a bottleneck. Thresholds: yellow=10s, red=30s.",
+          "title": "Semaphore Queue Wait",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 5
+                  },
+                  {
+                    "color": "red",
+                    "value": 10
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 0,
+            "y": 16
+          },
+          "id": 5,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(kube_booster_warmup_active_pods{namespace=~\"$namespace\"})",
+              "legendFormat": "Active Warmup Pods",
+              "refId": "A"
+            }
+          ],
+          "title": "Active Warmup Pods",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 8,
+            "y": 16
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(kube_booster_warmup_active_pods{namespace=~\"$namespace\"}) by (namespace)",
+              "legendFormat": "{{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Active Warmup Pods by Namespace",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 16
+          },
+          "id": 7,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(rate(kube_booster_warmup_requests_total{namespace=~\"$namespace\"}[5m]))",
+              "legendFormat": "Request Rate",
+              "refId": "A"
+            }
+          ],
+          "title": "Warmup Request Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 24
+          },
+          "id": 8,
+          "options": {
+            "legend": {
+              "calcs": [
+                "sum"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "${datasource}"
+              },
+              "expr": "sum(rate(kube_booster_warmup_total{namespace=~\"$namespace\"}[5m])) by (namespace, result) * 60",
+              "legendFormat": "{{namespace}} - {{result}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Warmup Rate by Namespace",
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 38,
+      "style": "dark",
+      "tags": [
+        "kube-booster",
+        "kubernetes",
+        "warmup"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {},
+            "hide": 0,
+            "includeAll": false,
+            "label": "Datasource",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "allValue": ".*",
+            "current": {},
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${datasource}"
+            },
+            "definition": "label_values(kube_booster_warmup_total, namespace)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Namespace",
+            "multi": true,
+            "name": "namespace",
+            "options": [],
+            "query": {
+              "query": "label_values(kube_booster_warmup_total, namespace)",
+              "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "type": "query"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "kube-booster Warmup Metrics",
+      "uid": "kube-booster-warmup",
+      "version": 2,
+      "weekStart": ""
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: monitoring
+  labels:
+    app: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - name: grafana
+        image: grafana/grafana:12.0.1
+        ports:
+        - containerPort: 3000
+          name: web
+        env:
+        - name: GF_AUTH_ANONYMOUS_ENABLED
+          value: "true"
+        - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+          value: "Admin"
+        volumeMounts:
+        - name: datasources
+          mountPath: /etc/grafana/provisioning/datasources
+        - name: dashboards-provider
+          mountPath: /etc/grafana/provisioning/dashboards
+        - name: dashboards
+          mountPath: /var/lib/grafana/dashboards
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+      volumes:
+      - name: datasources
+        configMap:
+          name: grafana-datasources
+      - name: dashboards-provider
+        configMap:
+          name: grafana-dashboards-provider
+      - name: dashboards
+        configMap:
+          name: grafana-dashboard-kube-booster
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  selector:
+    app: grafana
+  ports:
+  - name: web
+    port: 3000
+    targetPort: 3000
+  type: ClusterIP

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -24,12 +24,14 @@ var (
 		[]string{"namespace"},
 	)
 
-	// WarmupDurationSeconds is a histogram tracking time from warmup start to completion
+	// WarmupDurationSeconds is a histogram tracking time from warmup start to completion.
+	// Buckets extend to 120s so histogram_quantile gives accurate results up to and beyond
+	// the KubeBoosterSlowWarmup alert threshold of 60s.
 	WarmupDurationSeconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "kube_booster_warmup_duration_seconds",
 			Help:    "Time from warmup start to completion",
-			Buckets: prometheus.DefBuckets,
+			Buckets: []float64{.5, 1, 2.5, 5, 10, 15, 30, 45, 60, 90, 120},
 		},
 		[]string{"namespace"},
 	)


### PR DESCRIPTION
## Summary

- Adds `config/samples/monitoring.yaml` — a single-file monitoring stack that users can apply with one command to get Prometheus and Grafana observability for kube-booster
- Prometheus is deployed directly (no Operator) with Kubernetes pod service discovery scoped to `app.kubernetes.io/name=kube-booster` on port 8080, plus the four alerting rules from `docs/OBSERVABILITY.md`
- Grafana is deployed with the existing `config/samples/grafana-dashboard.json` dashboard pre-provisioned via ConfigMap, and the Prometheus datasource auto-configured

## Usage

```bash
kubectl apply -f config/samples/monitoring.yaml

# Access Grafana (dashboard is pre-loaded)
kubectl port-forward -n monitoring svc/grafana 3000:3000
```

## Test plan

- [ ] `kubectl apply -f config/samples/monitoring.yaml` creates all 12 resources without errors
- [ ] Prometheus pod reaches Running state and the kube-booster scrape target appears under Status → Targets
- [ ] Grafana pod reaches Running state; the "kube-booster Warmup Metrics" dashboard is visible at `http://localhost:3000` after port-forwarding
- [ ] Alerting rules load cleanly under Prometheus Status → Rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)